### PR TITLE
Replace deprecated .dict() with .model_dump()

### DIFF
--- a/src/models/AssetModel.py
+++ b/src/models/AssetModel.py
@@ -29,7 +29,7 @@ class AssetModel(BaseDataModel):
 
     async def create_asset(self, asset: Asset):
 
-        result = await self.collection.insert_one(asset.dict(by_alias=True, exclude_unset=True))
+        result = await self.collection.insert_one(asset.model_dump(by_alias=True, exclude_unset=True))
         asset.id = result.inserted_id
 
         return asset

--- a/src/models/ChunkModel.py
+++ b/src/models/ChunkModel.py
@@ -29,7 +29,7 @@ class ChunkModel(BaseDataModel):
                 )
 
     async def create_chunk(self, chunk: DataChunk):
-        result = await self.collection.insert_one(chunk.dict(by_alias=True, exclude_unset=True))
+        result = await self.collection.insert_one(chunk.model_dump(by_alias=True, exclude_unset=True))
         chunk._id = result.inserted_id
         return chunk
 
@@ -49,7 +49,7 @@ class ChunkModel(BaseDataModel):
             batch = chunks[i:i+batch_size]
 
             operations = [
-                InsertOne(chunk.dict(by_alias=True, exclude_unset=True))
+                InsertOne(chunk.model_dump(by_alias=True, exclude_unset=True))
                 for chunk in batch
             ]
 

--- a/src/models/ProjectModel.py
+++ b/src/models/ProjectModel.py
@@ -29,7 +29,7 @@ class ProjectModel(BaseDataModel):
 
     async def create_project(self, project: Project):
 
-        result = await self.collection.insert_one(project.dict(by_alias=True, exclude_unset=True))
+        result = await self.collection.insert_one(project.model_dump(by_alias=True, exclude_unset=True))
         project.id = result.inserted_id
 
         return project

--- a/src/routes/nlp.py
+++ b/src/routes/nlp.py
@@ -146,7 +146,7 @@ async def search_index(request: Request, project_id: str, search_request: Search
     return JSONResponse(
         content={
             "signal": ResponseSignal.VECTORDB_SEARCH_SUCCESS.value,
-            "results": [ result.dict()  for result in results ]
+            "results": [ result.model_dump()  for result in results ]
         }
     )
 


### PR DESCRIPTION
**Pull Request Title**:
Replace deprecated `.dict()` method with `.model_dump()`

**Description**:
This pull request replaces the use of the deprecated `.dict()` method with `.model_dump()`.

- **Changes Made**:
  - Updated occurrences of `.dict()` to `.model_dump()` to comply with updates in the underlying library.

**Reason for Changes**:
- The `.dict()` method is deprecated, and using `.model_dump()` ensures compatibility with the latest version of the library.
- This change future-proofs the codebase and avoids warnings or potential errors due to deprecated functionality.

### Additional Notes:
- This is a non-functional change that ensures compatibility and stability with newer library versions.