### PR TITLE
Update main.py to use lifespane instead of on_event

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,20 +2,19 @@ from fastapi import FastAPI
 from routes import base, data
 from motor.motor_asyncio import AsyncIOMotorClient
 from helpers.config import get_settings
+from contextlib import asynccontextmanager
 
-app = FastAPI()
-
-@app.on_event("startup")
-async def startup_db_client():
+@asynccontextmanager
+async def lifespan(app:FastAPI):
     settings = get_settings()
+
     app.mongo_conn = AsyncIOMotorClient(settings.MONGODB_URL)
     app.db_client = app.mongo_conn[settings.MONGODB_DATABASE]
 
-@app.on_event("shutdown")
-async def shutdown_db_client():
+    yield
+    
     app.mongo_conn.close()
 
-
+app = FastAPI(lifespan=lifespan)
 app.include_router(base.base_router)
 app.include_router(data.data_router)
-


### PR DESCRIPTION
`on_event` method is deprecated in newer versions of FastAPI, and it can be replaced by `lifespan`