### PR TITLE
Pull Request: Fix query embedding logic in CoHereProvider

### DIFF
--- a/src/stores/llm/providers/CoHereProvider.py
+++ b/src/stores/llm/providers/CoHereProvider.py
@@ -78,8 +78,11 @@ class CoHereProvider(LLMInterface):
             return None
         
         input_type = CoHereEnums.DOCUMENT
+        texts_to_embed = [ self.process_text(t) for t in text ]
+
         if document_type == DocumentTypeEnum.QUERY:
             input_type = CoHereEnums.QUERY
+            texts_to_embed = [ self.process_text(text) ]
 
         response = self.client.embed(
             model = self.embedding_model_id,


### PR DESCRIPTION
## Summary
Fixed a bug where query text was incorrectly processed as a list of characters, causing the embedding API to return a vector for each character. Now, queries are embedded as a single string, returning the correct embedding vector.

## Details
Query is now wrapped as a single string in a list before embedding.
Prevents character-level embeddings for queries.
This ensures correct embedding output for both documents and queries.