### PR TITLE
Update POSTMAN collection link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ open your browser and go to `http://localhost:5555` to see the dashboard.
 
 ## POSTMAN Collection
 
-Download the POSTMAN collection from [/assets/mini-rag-app.postman_collection.json](/assets/mini-rag-app.postman_collection.json)
+Download the POSTMAN collection from [src/assets/mini-rag-app.postman_collection.json](src/assets/mini-rag-app.postman_collection.json)


### PR DESCRIPTION
Fix Postman collection path in README to src/assets/mini-rag-app.postman_collection.json. this ensures the link functions correctly across the default branch (tut-017) and most other branches.